### PR TITLE
Fix ol.interaction.defaults type error

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -539,18 +539,31 @@
                 }
             });
             
+            // Create custom interactions array for OpenLayers v8
+            const interactions = [];
+            
+            // Add drag pan interaction
+            interactions.push(new ol.interaction.DragPan());
+            
+            // Add mouse wheel zoom conditionally for desktop
+            if (!isMobile) {
+                interactions.push(new ol.interaction.MouseWheelZoom());
+            }
+            
+            // Add pinch zoom conditionally for mobile
+            if (isMobile) {
+                interactions.push(new ol.interaction.PinchZoom());
+            }
+            
+            // Add drag rotate (but not double-click zoom as it was disabled)
+            interactions.push(new ol.interaction.DragRotate());
+            
             // Create map
             map = new ol.Map({
                 target: 'map',
                 layers: [satelliteLayer, vectorLayer],
                 view: view,
-                interactions: ol.interaction.defaults({
-                    doubleClickZoom: false,
-                    keyboard: false,
-                    mouseWheelZoom: !isMobile,
-                    pinchZoom: isMobile,
-                    dragPan: true
-                }),
+                interactions: interactions,
                 controls: [] // Remove default controls
             });
             


### PR DESCRIPTION
Fix `ol.interaction.defaults is not a function` error by replacing deprecated interaction defaults with explicit OpenLayers v8 interactions.

---
<a href="https://cursor.com/background-agent?bcId=bc-abae44c4-eef1-4b07-ae79-ca5598373277">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-abae44c4-eef1-4b07-ae79-ca5598373277">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

